### PR TITLE
Fix port configuration script

### DIFF
--- a/.devcontainer/post_start.sh
+++ b/.devcontainer/post_start.sh
@@ -2,5 +2,6 @@
 # This script is run after the container is started.
 
 # open ports for Python Django server and React app
-gh cs ports visibility 8000:public -c $CODESPACE_NAME
-gh cs ports visibility 3000:public -c $CODESPACE_NAME
+# Use the full `codespace` subcommand to avoid issues with shell aliasing
+gh codespace ports visibility 8000:public -c "$CODESPACE_NAME"
+gh codespace ports visibility 3000:public -c "$CODESPACE_NAME"


### PR DESCRIPTION
## Summary
- fix `post_start.sh` to use `gh codespace` instead of the shortened `gh cs`
- add quoting and newline cleanup for reliability

## Testing
- `bash -n .devcontainer/post_start.sh`

------
https://chatgpt.com/codex/tasks/task_b_68573d7fd800832f8e5178701651809a